### PR TITLE
[Add] Add a feature to print symbolic links

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -8,14 +9,17 @@ import (
 func GatherFileInfo(files []string) map[string]fInfo {
 	inf := map[string]fInfo{}
 	for _, fPath := range files {
-		fileinfo, _ := os.Stat(fPath)
+		fileinfo, _ := os.Lstat(fPath)
 
 		_, filename := filepath.Split(fPath)
 
 		var fi fInfo
 		fi.fileName = filename
 		fi.fileMode = fileinfo.Mode()
-		fi.fileMode = fileinfo.Mode()
+		if fi.fileMode&fs.ModeSymlink != 0 {
+			fi.linkPath, _ = os.Readlink(fPath)
+		}
+
 		fi.fileSize = fileinfo.Size()
 		owner, group := GetOwnerGroup(fPath, fileinfo)
 		fi.ownerName = owner

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 type fInfo struct {
 	fileName   string
 	fileMode   fs.FileMode
+	linkPath   string
 	fileSize   int64
 	ownerName  string
 	groupName  string

--- a/print.go
+++ b/print.go
@@ -24,7 +24,11 @@ func printUpdateDate(f fInfo) {
 }
 
 func printFilename(f fInfo) {
-	fmt.Printf("%s  ", f.fileName)
+	if f.linkPath != "" {
+		fmt.Printf("%s  →  %s  ", f.fileName, f.linkPath)
+	} else {
+		fmt.Printf("%s  ", f.fileName)
+	}
 }
 
 func DisplayLongFormat(files map[string]fInfo) {


### PR DESCRIPTION
Add the function to print the contents of symbolic link paths.
```
> go-ls.exe -la 
Total files:  1
Lrw-rw-rw-   XXX XXX   0  Apr 15 18:41:51 2023  test  → ..\go-ls
```